### PR TITLE
Don't pass area when not using areas

### DIFF
--- a/System.Web.Mvc.Expressions/ControllerExtensions.cs
+++ b/System.Web.Mvc.Expressions/ControllerExtensions.cs
@@ -6,6 +6,7 @@
     using System.Web.Mvc;
     using System.Web.Mvc.Expressions.Internals;
     using System.Web.Routing;
+    using static System.Web.Mvc.Expressions.Internals.RouteCollectionExtensions;
 
     public static class ControllerExtensions
     {
@@ -89,6 +90,10 @@
         {
             var routeValuesDictionary = new RouteValueDictionary(routeValues);
             routeValuesDictionary.AddRouteValuesFromExpression<TRedirectController>(action);
+            if (!DetermineUsingAreas(RouteTable.Routes))
+            {
+                routeValuesDictionary.Remove("area");
+            }
 
             return new RedirectToRouteResult(null, routeValuesDictionary, permanent);
         }

--- a/System.Web.Mvc.Expressions/HtmlHelperExtensions.cs
+++ b/System.Web.Mvc.Expressions/HtmlHelperExtensions.cs
@@ -6,6 +6,7 @@
     using System.Web.Mvc;
     using System.Web.Mvc.Expressions.Internals;
     using System.Web.Mvc.Html;
+    using static System.Web.Mvc.Expressions.Internals.RouteCollectionExtensions;
 
     public static class HtmlHelperExtensions
     {
@@ -18,6 +19,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return helper.BeginForm(
                 routeInfo.ActionName,
                 routeInfo.ControllerName,
@@ -35,6 +41,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return helper.BeginForm(
                 routeInfo.ActionName,
                 routeInfo.ControllerName,
@@ -52,6 +63,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return helper.ActionLink(
                 linkText,
                 routeInfo.ActionName,
@@ -69,6 +85,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return helper.ActionLink(
                 linkText,
                 routeInfo.ActionName,
@@ -84,6 +105,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             helper.RenderAction(routeInfo.ActionName, routeInfo.ControllerName, routeInfo.RouteValueDictionary);
         }
 
@@ -94,6 +120,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             helper.RenderAction(routeInfo.ActionName, routeInfo.ControllerName, routeInfo.RouteValueDictionary);
         }
 
@@ -104,6 +135,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return helper.Action(routeInfo.ActionName, routeInfo.ControllerName, routeInfo.RouteValueDictionary);
         }
 
@@ -114,6 +150,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(helper.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return helper.Action(routeInfo.ActionName, routeInfo.ControllerName, routeInfo.RouteValueDictionary);
         }
     }

--- a/System.Web.Mvc.Expressions/Internals/AreaHelpers.cs
+++ b/System.Web.Mvc.Expressions/Internals/AreaHelpers.cs
@@ -1,0 +1,28 @@
+﻿// taken from System.Web.Mvc.AreaHelpers.GetAreaName
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Web.Mvc.Expressions.Internals
+{
+    using System.Web.Routing;
+
+    internal static class AreaHelpers
+    {
+        public static string GetAreaName(RouteBase route)
+        {
+            IRouteWithArea routeWithArea = route as IRouteWithArea;
+            if (routeWithArea != null)
+            {
+                return routeWithArea.Area;
+            }
+
+            Route castRoute = route as Route;
+            if (castRoute != null && castRoute.DataTokens != null)
+            {
+                return castRoute.DataTokens["area"] as string;
+            }
+
+            return null;
+        }
+    }
+}

--- a/System.Web.Mvc.Expressions/Internals/RouteCollectionExtensions.cs
+++ b/System.Web.Mvc.Expressions/Internals/RouteCollectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Modelled after System.Web.Mvc.RouteCollectionExtensions.FilterRouteCollectionByArea
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Web.Mvc.Expressions.Internals
+{
+    using System.Web.Routing;
+
+    internal class RouteCollectionExtensions
+    {
+        internal static bool DetermineUsingAreas(RouteCollection routes)
+        {
+            using (routes.GetReadLock())
+            {
+                foreach (RouteBase route in routes)
+                {
+                    string a = AreaHelpers.GetAreaName(route) ?? string.Empty;
+                    if (a.Length > 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/System.Web.Mvc.Expressions/System.Web.Mvc.Expressions.csproj
+++ b/System.Web.Mvc.Expressions/System.Web.Mvc.Expressions.csproj
@@ -72,7 +72,9 @@
     <Compile Include="AjaxHelperExtensions.cs" />
     <Compile Include="ControllerExtensions.cs" />
     <Compile Include="HtmlHelperExtensions.cs" />
+    <Compile Include="Internals\AreaHelpers.cs" />
     <Compile Include="Internals\ExpressionHelpers.cs" />
+    <Compile Include="Internals\RouteCollectionExtensions.cs" />
     <Compile Include="ModelStateDictionaryExtensions.cs" />
     <Compile Include="Internals\MvcExtensions.cs" />
     <Compile Include="Internals\RouteValueDictionaryExtensions.cs" />

--- a/System.Web.Mvc.Expressions/UrlHelperExtensions.cs
+++ b/System.Web.Mvc.Expressions/UrlHelperExtensions.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using System.Web.Mvc;
     using System.Web.Mvc.Expressions.Internals;
+    using static System.Web.Mvc.Expressions.Internals.RouteCollectionExtensions;
 
     public static class UrlHelperExtensions
     {
@@ -15,6 +16,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(url.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return url.Action(routeInfo.ActionName, routeInfo.ControllerName, routeInfo.RouteValueDictionary);
         }
 
@@ -25,6 +31,11 @@
             where TController : Controller
         {
             var routeInfo = RouteInformation.FromExpression<TController>(action, routeValues);
+            if (!DetermineUsingAreas(url.RouteCollection))
+            {
+                routeInfo.RouteValueDictionary.Remove("area");
+            }
+
             return url.Action(routeInfo.ActionName, routeInfo.ControllerName, routeInfo.RouteValueDictionary);
         }
     }


### PR DESCRIPTION
When area is passed when we're not using areas, generated urls in child actions will have `?area=` appended to them. This is caused by the following:

`ChildActionExtensions.ActionHelper` [calls][0] `RouteCollectionExtensions.GetVirtualPathForArea` which [loops over][1] the configured routes and sets `usingAreas` to `true` if there's a route found with an area. Then back in the `ActionHelper` it will [remove the `area` from the route values][2] when `usingAreas` was set to `true`.

So when we're not using areas, `ActionHelper` will pass the key `area` with value `""` in the `RouteData` to `Server.Execute`.

Finally when in `UrlHelper.GenerateUrl` it [merges the route values from the request][3] and the resulting `mergedRouteValues` will contain a key `area`. This is then [passed to `RouteCollectionExtensions.GetVirtualPathForArea`][4] which will [remove the key `area` but only if (again) `usingAreas` is `true`][5].

[0]: https://github.com/aspnet/AspNetWebStack/blob/ba26cfbfbf958d548e4c0a96e853250f13450dc6/src/System.Web.Mvc/Html/ChildActionExtensions.cs#L108
[1]: https://github.com/aspnet/AspNetWebStack/blob/ba26cfbfbf958d548e4c0a96e853250f13450dc6/src/System.Web.Mvc/RouteCollectionExtensions.cs#L41
[2]: https://github.com/aspnet/AspNetWebStack/blob/ba26cfbfbf958d548e4c0a96e853250f13450dc6/src/System.Web.Mvc/Html/ChildActionExtensions.cs#L119
[3]: https://github.com/aspnet/AspNetWebStack/blob/ba26cfbfbf958d548e4c0a96e853250f13450dc6/src/System.Web.Mvc/UrlHelper.cs#L188
[4]: https://github.com/aspnet/AspNetWebStack/blob/ba26cfbfbf958d548e4c0a96e853250f13450dc6/src/System.Web.Mvc/UrlHelper.cs#L190
[5]: https://github.com/aspnet/AspNetWebStack/blob/ba26cfbfbf958d548e4c0a96e853250f13450dc6/src/System.Web.Mvc/RouteCollectionExtensions.cs#L102