### PR TITLE
Overload that defaults to FormMethod.Post

### DIFF
--- a/System.Web.Mvc.Expressions/HtmlHelperExtensions.cs
+++ b/System.Web.Mvc.Expressions/HtmlHelperExtensions.cs
@@ -10,6 +10,33 @@
 
     public static class HtmlHelperExtensions
     {
+        /// <summary>Writes an opening &lt;form&gt; tag to the response and sets the action tag to the specified controller and action. The form uses the POST method.</summary>
+        /// <returns>An opening &lt;form&gt; tag.</returns>
+        public static MvcForm BeginForm<TController>(
+            this HtmlHelper helper,
+            Expression<Action<TController>> action,
+            object routeValues = null,
+            object htmlAttributes = null)
+            where TController : Controller
+        {
+            return helper.BeginForm(action, FormMethod.Post, routeValues, htmlAttributes);
+        }
+
+        /// <summary>Writes an opening &lt;form&gt; tag to the response and sets the action tag to the specified controller and action. The form uses the POST method.</summary>
+        /// <returns>An opening &lt;form&gt; tag.</returns>
+        public static MvcForm BeginForm<TController>(
+            this HtmlHelper helper,
+            Expression<Func<TController, Task>> action,
+            object routeValues = null,
+            object htmlAttributes = null)
+            where TController : Controller
+        {
+            return helper.BeginForm(action, FormMethod.Post, routeValues, htmlAttributes);
+        }
+
+
+        /// <summary>Writes an opening &lt;form&gt; tag to the response and sets the action tag to the specified controller and action. The form uses the specified HTTP method and includes the HTML attributes.</summary>
+        /// <returns>An opening &lt;form&gt; tag.</returns>
         public static MvcForm BeginForm<TController>(
                 this HtmlHelper helper,
                 Expression<Action<TController>> action,
@@ -32,6 +59,8 @@
                 HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
         }
 
+        /// <summary>Writes an opening &lt;form&gt; tag to the response and sets the action tag to the specified controller and action. The form uses the specified HTTP method and includes the HTML attributes.</summary>
+        /// <returns>An opening &lt;form&gt; tag.</returns>
         public static MvcForm BeginForm<TController>(
                 this HtmlHelper helper,
                 Expression<Func<TController, Task>> action,


### PR DESCRIPTION
Similar to ASP.NET MVC's default helpers, this overload doesn't require specifying `FormMethod.Post` on every invocation.